### PR TITLE
feat: dark mode

### DIFF
--- a/components/theme-provider.tsx
+++ b/components/theme-provider.tsx
@@ -1,0 +1,9 @@
+'use client';
+
+import * as React from 'react';
+import { ThemeProvider as NextThemesProvider } from 'next-themes';
+import { type ThemeProviderProps } from 'next-themes/dist/types';
+
+export function ThemeProvider({ children, ...props }: ThemeProviderProps) {
+  return <NextThemesProvider {...props}>{children}</NextThemesProvider>;
+}


### PR DESCRIPTION
이전 브랜치과 내용이 섞임

- `npm install next-themes` : shadcn에서 제공하는 theme 설정 라이브러리 추가 (전체적인 테마)
- `npm install @clerk/themes` : clerk에서 제공하는 theme 설정 라이브러리 추가 (로그인 창/ 회원가입 창에서 사용)


[clerk theme 설정]
1. 루트레이아웃에 `<ClerkProvider/>` 의 ` appearance`에 `baseTheme:dark` 설정

[shadcm theme 설정]
1. <ThemeProvider/> 생성
2. 루트 레이아웃에서 `<ThemeProvider/>` 관련 설정